### PR TITLE
Negative extensions, SE Depth PV.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -507,7 +507,7 @@ int negamax(int alpha, int beta, int depth, Board &board, SearchInfo &info, Sear
         /* Extensions
          * Search extra ply if move comes from tt
          */
-        if (!is_root && depth >= 7 && (move == tte.move) && (tte.flag & HFBETA) && abs(tte.score) < ISMATE &&
+        if (!is_root && depth >= (6 + is_pvnode) && (move == tte.move) && (tte.flag & HFBETA) && abs(tte.score) < ISMATE &&
             tte.depth >= depth - 3)
         {
 
@@ -535,6 +535,8 @@ int negamax(int alpha, int beta, int depth, Board &board, SearchInfo &info, Sear
             else if (tte.score >= beta)
             {
                 extension = -2;
+            }else if (tte.score <= singular_score){
+                extension = -1;
             }
         }
 


### PR DESCRIPTION
SE Depth at 6.
Depth at 7 if at pv node.
Negative extension if TT score that is lower than singular score

ELO   | 5.65 +- 4.34 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13232 W: 3670 L: 3455 D: 6107