### PR TITLE
Continuation History Update

### DIFF
--- a/src/movescore.cpp
+++ b/src/movescore.cpp
@@ -2,7 +2,7 @@
 #include "eval.h"
 #include "see.h"
 
-int mvv_lva[12][12] = {
+constexpr int mvv_lva[12][12] = {
     105, 205, 305, 405, 505, 605, 105, 205, 305, 405, 505, 605, 104, 204, 304,
     404, 504, 604, 104, 204, 304, 404, 504, 604, 103, 203, 303, 403, 503, 603,
     103, 203, 303, 403, 503, 603, 102, 202, 302, 402, 502, 602, 102, 202, 302,
@@ -21,10 +21,10 @@ static inline int get_conthist_score(SearchThread& st, SearchStack *ss,
     int score = 0;
 
     if (ss->ply >= 1 && (ss-1)->move && (ss-1)->moved_piece != None && move){
-         score += st.contHist[(ss - 1)->moved_piece][to((ss - 1)->move)][st.board.pieceAtB(from(move))][to(move)];
+         score += (ss - 1)->continuationHistory[st.board.pieceAtB(from(move))][to(move)];
 
         if (ss->ply >= 2 && (ss-2)->move && (ss-2)->moved_piece != None && move) {
-            score += st.contHist[(ss - 2)->moved_piece][to((ss - 2)->move)][st.board.pieceAtB(from(move))][to(move)];
+            score += (ss - 2)->continuationHistory[st.board.pieceAtB(from(move))][to(move)];
         }
     }
 
@@ -103,11 +103,10 @@ static inline void update_ch(SearchThread& st, SearchStack *ss,
                              const Move move, const int score) {
 
     if (ss->ply >= 1 && (ss - 1)->moved_piece != None){
-        st.contHist[(ss - 1)->moved_piece][to((ss - 1)->move)]
-                         [st.board.pieceAtB(from(move))][to(move)] += score;
+        (ss-1)->continuationHistory[st.board.pieceAtB(from(move))][to(move)] += score;
+
         if (ss->ply >= 2 && (ss - 1)->moved_piece != None) {
-            st.contHist[(ss - 2)->moved_piece][to((ss - 2)->move)]
-                         [st.board.pieceAtB(from(move))][to(move)] += score;
+            (ss-2)->continuationHistory[st.board.pieceAtB(from(move))][to(move)] += score;
         }
     }
 }
@@ -152,7 +151,7 @@ void get_history_scores(int &his, int &ch, int &fmh, SearchThread& st, SearchSta
 
     his = st.searchHistory[st.board.pieceAtB(from(move))][to(move)];
 
-    ch = previous_move && (ss-1)->moved_piece != None ? st.contHist.at((ss-1)->moved_piece).at(to(previous_move)).at(moved_piece).at(to(move)) : 0;
+    ch = previous_move && (ss-1)->moved_piece != None ? (ss - 1)->continuationHistory.at(moved_piece).at(to(move)) : 0;
 
-    fmh = previous_previous_move && (ss - 2)->moved_piece != None ? st.contHist.at((ss - 2)->moved_piece).at(to(previous_previous_move)).at(moved_piece).at(to(move)) : 0;
+    fmh = previous_previous_move && (ss - 2)->moved_piece != None ? (ss - 2)->continuationHistory.at(moved_piece).at(to(move)) : 0;
 }

--- a/src/movescore.cpp
+++ b/src/movescore.cpp
@@ -106,18 +106,19 @@ void updateCH(int16_t& historyScore, const int bonus) {
     historyScore += bonus - historyScore * std::abs(bonus) / MAXCOUNTERHISTORY;
 }
 
-void updateH(int16_t& historyScore, const int bonus){
+void updateH(int16_t& historyScore, const int bonus)
+{
     historyScore += bonus - historyScore * std::abs(bonus) / MAXHISTORY;
 }
 
-void updateContinuationHistories(SearchStack *ss, Move move, int bonus){
+void updateContinuationHistories(SearchStack* ss, Piece piece, Move move, int bonus){
 
     if ((ss - 1)->move){
-        updateCH((ss - 1)->continuationHistory[ss->moved_piece][to(move)], bonus);
+        updateCH((ss - 1)->continuationHistory[piece][to(move)], bonus);
     }
 
     if ((ss-2)->move){
-        updateCH((ss - 2)->continuationHistory[ss->moved_piece][to(move)], bonus);   
+        updateCH((ss - 2)->continuationHistory[piece][to(move)], bonus);   
     }
 }
 
@@ -125,7 +126,7 @@ void updateHistories(SearchThread& st, SearchStack *ss, Move bestmove, Movelist 
     // Update best move score
     int bonus = historyBonus(depth);
 
-    updateContinuationHistories(ss, bestmove, bonus);
+    updateContinuationHistories(ss, st.board.pieceAtB(from(bestmove)), bestmove, bonus);
     
     updateH(st.searchHistory[st.board.pieceAtB(from(bestmove))][to(bestmove)], bonus);
 
@@ -136,7 +137,7 @@ void updateHistories(SearchThread& st, SearchStack *ss, Move bestmove, Movelist 
             continue; // Don't give penalty to our best move, so skip it.
 
         // Penalize moves that didn't cause a beta cutoff.
-        updateContinuationHistories(ss, move, -bonus);
+        updateContinuationHistories(ss, st.board.pieceAtB(from(move)), move, -bonus);
         updateH(st.searchHistory[st.board.pieceAtB(from(move))][to(move)], -bonus);
     }
 }

--- a/src/movescore.h
+++ b/src/movescore.h
@@ -6,15 +6,29 @@
 #define MAXHISTORY 16384
 #define MAXCOUNTERHISTORY 16384
 
+constexpr int mvv_lva[12][12] = {
+    105, 205, 305, 405, 505, 605, 105, 205, 305, 405, 505, 605, 104, 204, 304,
+    404, 504, 604, 104, 204, 304, 404, 504, 604, 103, 203, 303, 403, 503, 603,
+    103, 203, 303, 403, 503, 603, 102, 202, 302, 402, 502, 602, 102, 202, 302,
+    402, 502, 602, 101, 201, 301, 401, 501, 601, 101, 201, 301, 401, 501, 601,
+    100, 200, 300, 400, 500, 600, 100, 200, 300, 400, 500, 600,
+
+    105, 205, 305, 405, 505, 605, 105, 205, 305, 405, 505, 605, 104, 204, 304,
+    404, 504, 604, 104, 204, 304, 404, 504, 604, 103, 203, 303, 403, 503, 603,
+    103, 203, 303, 403, 503, 603, 102, 202, 302, 402, 502, 602, 102, 202, 302,
+    402, 502, 602, 101, 201, 301, 401, 501, 601, 101, 201, 301, 401, 501, 601,
+    100, 200, 300, 400, 500, 600, 100, 200, 300, 400, 500, 600};
+
 void score_moves(SearchThread& st, Movelist &list, SearchStack *ss, Move tt_move);
 void score_moves(Board &board, Movelist &list, Move tt_move);
 
 void pick_nextmove(const int moveNum, Movelist &list);
 
+void updateContinuationHistories(SearchStack* ss, Piece piece, Move move, int bonus);
 void updateHistories(SearchThread& st, SearchStack *ss, Move bestmove, Movelist &quietList, int depth);
 
 inline int historyBonus(int depth){
-   return depth > 13 ? 32 : 16 * depth * depth + 128 * std::max(depth - 1, 0);
+   return std::min(2100, 300 * depth - 300);
 }
 
 void get_history_scores(int& hus, int& ch, int& fmh, SearchThread& st, SearchStack *ss, const Move move);

--- a/src/movescore.h
+++ b/src/movescore.h
@@ -3,7 +3,7 @@
 #include "types.h"
 #include "search.h"
 
-#define MAXHISTORY 16384
+#define MAXHISTORY 8192
 #define MAXCOUNTERHISTORY 16384
 
 void score_moves(SearchThread& st, Movelist &list, SearchStack *ss, Move tt_move);
@@ -11,12 +11,10 @@ void score_moves(Board &board, Movelist &list, Move tt_move);
 
 void pick_nextmove(const int moveNum, Movelist &list);
 
-void updateContinuationHistories(SearchStack *ss, Move move, int bonus);
-
 void updateHistories(SearchThread& st, SearchStack *ss, Move bestmove, Movelist &quietList, int depth);
 
 inline int historyBonus(int depth){
-    return std::min(depth * depth, 1200);
+    return std::min(2100, 350 * depth - 350);
 }
 
 void get_history_scores(int& hus, int& ch, int& fmh, SearchThread& st, SearchStack *ss, const Move move);

--- a/src/movescore.h
+++ b/src/movescore.h
@@ -3,8 +3,8 @@
 #include "types.h"
 #include "search.h"
 
-#define MAXHISTORY 8196
-#define MAXCOUNTERHISTORY 16000
+#define MAXHISTORY 16384
+#define MAXCOUNTERHISTORY 16384
 
 void score_moves(SearchThread& st, Movelist &list, SearchStack *ss, Move tt_move);
 void score_moves(Board &board, Movelist &list, Move tt_move);

--- a/src/movescore.h
+++ b/src/movescore.h
@@ -3,7 +3,7 @@
 #include "types.h"
 #include "search.h"
 
-#define MAXHISTORY 8192
+#define MAXHISTORY 16384
 #define MAXCOUNTERHISTORY 16384
 
 void score_moves(SearchThread& st, Movelist &list, SearchStack *ss, Move tt_move);
@@ -14,7 +14,7 @@ void pick_nextmove(const int moveNum, Movelist &list);
 void updateHistories(SearchThread& st, SearchStack *ss, Move bestmove, Movelist &quietList, int depth);
 
 inline int historyBonus(int depth){
-    return std::min(2100, 350 * depth - 350);
+   return depth > 13 ? 32 : 16 * depth * depth + 128 * std::max(depth - 1, 0);
 }
 
 void get_history_scores(int& hus, int& ch, int& fmh, SearchThread& st, SearchStack *ss, const Move move);

--- a/src/movescore.h
+++ b/src/movescore.h
@@ -4,7 +4,7 @@
 #include "search.h"
 
 #define MAXHISTORY 8196
-#define MAXCOUNTERHISTORY 8196
+#define MAXCOUNTERHISTORY 16000
 
 void score_moves(SearchThread& st, Movelist &list, SearchStack *ss, Move tt_move);
 void score_moves(Board &board, Movelist &list, Move tt_move);

--- a/src/movescore.h
+++ b/src/movescore.h
@@ -4,7 +4,7 @@
 #include "search.h"
 
 #define MAXHISTORY 8196
-#define MAXCOUNTERHISTORY 16000
+#define MAXCOUNTERHISTORY 8196
 
 void score_moves(SearchThread& st, Movelist &list, SearchStack *ss, Move tt_move);
 void score_moves(Board &board, Movelist &list, Move tt_move);

--- a/src/movescore.h
+++ b/src/movescore.h
@@ -11,7 +11,7 @@ void score_moves(Board &board, Movelist &list, Move tt_move);
 
 void pick_nextmove(const int moveNum, Movelist &list);
 
-void update_conthist_move(SearchThread& st, SearchStack *ss, Move move, int bonus);
+void updateContinuationHistories(SearchStack *ss, Move move, int bonus);
 
 void updateHistories(SearchThread& st, SearchStack *ss, Move bestmove, Movelist &quietList, int depth);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -110,6 +110,7 @@ int qsearch(int alpha, int beta, SearchThread& st, SearchStack *ss)
         pick_nextmove(i, list);
 
         Move move = list[i].move;
+        ss->moved_piece = st.board.pieceAtB(to(move));
 
         /* SEE pruning in qsearch search */
         /* If we do not SEE a good capture move, we can skip the move.*/
@@ -128,7 +129,6 @@ int qsearch(int alpha, int beta, SearchThread& st, SearchStack *ss)
         move_count++;
 
         ss->move = move;
-        ss->moved_piece = st.board.pieceAtB(to(move));
 
         /* Recursive call of qsearch on current position */
         score = -qsearch(-beta, -alpha, st, ss + 1);
@@ -381,7 +381,6 @@ int negamax(int alpha, int beta, int depth, SearchThread& st, SearchStack *ss)
     Movegen::legalmoves<ALL>(board, list);
 
     Movelist quietList;   // Quiet moves list
-    Movelist captureList; // Capture moveslist
 
     // Score moves and pass the tt move so it can be sorted highest
     score_moves(st, list, ss, tte.move);
@@ -397,6 +396,7 @@ int negamax(int alpha, int beta, int depth, SearchThread& st, SearchStack *ss)
         // Initialize move variable
         Move move = list[i].move;
         Piece moved_piece = board.pieceAtB(from(move));
+        ss->moved_piece = moved_piece;
 
         // Skip excluded moves from extension
         if (move == ss->excluded)
@@ -404,21 +404,12 @@ int negamax(int alpha, int beta, int depth, SearchThread& st, SearchStack *ss)
 
         bool is_quiet = (!promoted(move) && !is_capture(board, move));
         int extension = 0;
-
-        int h = 0, ch = 0, fh = 0;
-        int history = 0;
-
+        
         bool refutationMove = (ss->killers[0] == move || ss->killers[1] == move);
 
         if (is_quiet && skip_quiet_moves)
         {
             continue;
-        }
-
-        if (is_quiet)
-        {
-            get_history_scores(h, ch, fh, st, ss, move);
-            history = h + ch + fh;
         }
 
         /* Various pruning techniques */
@@ -509,7 +500,6 @@ int negamax(int alpha, int beta, int depth, SearchThread& st, SearchStack *ss)
 
         /* Set stack move to current move */
         ss->move = move;
-        ss->moved_piece = moved_piece;
 
         /* Increment ply, nodes and movecount */
         (ss + 1)->ply = ss->ply + 1;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -772,7 +772,11 @@ int aspiration_window(int prevEval, int depth, SearchThread& st)
 {
     int score = 0;
 
-    SearchStack stack[MAXPLY + 10], *ss = stack + 7;
+    // SearchStack stack[MAXPLY + 10], *ss = stack + 7;
+
+    auto heapAllocatedSearchStack = std::make_unique<std::array<SearchStack, MAXPLY+10>>();
+    SearchStack *stack = heapAllocatedSearchStack->data();
+    SearchStack *ss = stack + 7;
 
     int delta = 12;
 
@@ -817,8 +821,6 @@ int aspiration_window(int prevEval, int depth, SearchThread& st)
             break;
         }
         delta += delta / 2;
-
-        // std::cout << "DELTA: " << delta << std::endl;
     }
 
     return score;

--- a/src/search.h
+++ b/src/search.h
@@ -35,13 +35,14 @@ struct SearchStack {
     Move killers[2] = {NO_MOVE, NO_MOVE};
 
     Piece moved_piece{None};
+
+    HistoryTable continuationHistory;
 };
 
 struct SearchThread{
 
     HistoryTable searchHistory;
-    ContinuationHistoryTable contHist;
-    
+
     NNUE::Net nnue;
 
     Board board;
@@ -60,8 +61,7 @@ struct SearchThread{
         nodes_reached = 0;
 
         memset(searchHistory.data(), 0, sizeof(searchHistory));
-        memset(contHist.data(), 0, sizeof(contHist));
-        
+
         board.refresh(nnue);
 
         tm.reset();

--- a/src/search.h
+++ b/src/search.h
@@ -36,16 +36,13 @@ struct SearchStack {
 
     Piece moved_piece{None};
 
-    HistoryTable continuationHistory;
-
-    SearchStack(){
-        memset(continuationHistory.data(), 0, sizeof(continuationHistory));
-    }
+    HistoryTable* continuationHistory;
 };
 
 struct SearchThread{
 
     HistoryTable searchHistory;
+    HistoryTable continuationHistory[13][64];
 
     NNUE::Net nnue;
 
@@ -65,6 +62,7 @@ struct SearchThread{
         nodes_reached = 0;
 
         memset(searchHistory.data(), 0, sizeof(searchHistory));
+        memset(continuationHistory, 0, sizeof(continuationHistory));
 
         board.refresh(nnue);
 

--- a/src/search.h
+++ b/src/search.h
@@ -37,6 +37,10 @@ struct SearchStack {
     Piece moved_piece{None};
 
     HistoryTable continuationHistory;
+
+    SearchStack(){
+        memset(continuationHistory.data(), 0, sizeof(continuationHistory));
+    }
 };
 
 struct SearchThread{


### PR DESCRIPTION
Use continuation history in SearchStack. Also the bonus is changed from depth * depth to 300 * depth - 300.
Potential bug has been fixed for continuation history (updating bug).

ELO   | 23.03 +- 10.40 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2312 W: 699 L: 546 D: 1067