### PR TITLE
Reduce according to History in LMR

### DIFF
--- a/src/movescore.cpp
+++ b/src/movescore.cpp
@@ -139,8 +139,8 @@ int get_history_scores(int &his, int &ch, int &fmh, SearchThread& st, SearchStac
 
     his = st.searchHistory[st.board.pieceAtB(from(move))][to(move)];
 
-    ch = (*(ss - 1)->continuationHistory)[moved_piece][to(move)];
-    fmh = (*(ss - 2)->continuationHistory)[moved_piece][to(move)];
+    ch = (ss-1)->move ? (*(ss - 1)->continuationHistory)[moved_piece][to(move)] : 0;
+    fmh = (ss-2)->move ? (*(ss - 2)->continuationHistory)[moved_piece][to(move)] : 0;
 
     return his + ch + fmh;
 }

--- a/src/movescore.cpp
+++ b/src/movescore.cpp
@@ -132,7 +132,7 @@ void updateHistories(SearchThread& st, SearchStack *ss, Move bestmove, Movelist 
     }
 }
 
-void get_history_scores(int &his, int &ch, int &fmh, SearchThread& st, SearchStack *ss, const Move move) {
+int get_history_scores(int &his, int &ch, int &fmh, SearchThread& st, SearchStack *ss, const Move move) {
     Move previous_move = (ss - 1)->move;
     Move previous_previous_move = (ss - 2)->move;
     Piece moved_piece = st.board.pieceAtB(from(move));
@@ -141,4 +141,6 @@ void get_history_scores(int &his, int &ch, int &fmh, SearchThread& st, SearchSta
 
     ch = (*(ss - 1)->continuationHistory)[moved_piece][to(move)];
     fmh = (*(ss - 2)->continuationHistory)[moved_piece][to(move)];
+
+    return his + ch + fmh;
 }

--- a/src/movescore.h
+++ b/src/movescore.h
@@ -31,4 +31,4 @@ inline int historyBonus(int depth){
    return std::min(2100, 300 * depth - 300);
 }
 
-void get_history_scores(int& hus, int& ch, int& fmh, SearchThread& st, SearchStack *ss, const Move move);
+int get_history_scores(int& hus, int& ch, int& fmh, SearchThread& st, SearchStack *ss, const Move move);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -549,7 +549,7 @@ int negamax(int alpha, int beta, int depth, SearchThread& st, SearchStack *ss)
             reduction -= refutationMove * 2; 
 
             // Reduce or Increase according to history score
-            reduction -= std::clamp(history/16384, -2, 2);
+            reduction -= history/4000;
 
             /* Adjust the reduction so we don't drop into Qsearch or cause an
              * extension*/

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -414,6 +414,9 @@ int negamax(int alpha, int beta, int depth, SearchThread& st, SearchStack *ss)
         
         bool refutationMove = (ss->killers[0] == move || ss->killers[1] == move);
 
+        int hist = 0, counter_hist = 0, follow_up_hist = 0;
+        int history = get_history_scores(hist, counter_hist, follow_up_hist, st, ss, move);
+
         if (is_quiet && skip_quiet_moves)
         {
             continue;
@@ -544,6 +547,9 @@ int negamax(int alpha, int beta, int depth, SearchThread& st, SearchStack *ss)
 
             // Reduce two plies if it's a counter or killer
             reduction -= refutationMove * 2; 
+
+            // Reduce or Increase according to history score
+            reduction -= std::clamp(history/16384, -2, 2);
 
             /* Adjust the reduction so we don't drop into Qsearch or cause an
              * extension*/


### PR DESCRIPTION
ELO   | 10.42 +- 6.81 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 5304 W: 1489 L: 1330 D: 2485