### PR TITLE
Perform IIR on cutnodes according to cj5716

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -375,6 +375,9 @@ int negamax(int alpha, int beta, int depth, SearchThread& st, SearchStack *ss, b
         }
     }
 
+    if (cutnode && depth >= 7 && tte.move == NO_MOVE) 
+        depth--;
+
     /* Initialize variables */
     int bestscore = -INF_BOUND;
     int move_count = 0;


### PR DESCRIPTION
ELO   | 5.77 +- 4.37 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13016 W: 3601 L: 3385 D: 6030