### PR TITLE
Search.cpp - Fix bitwise-OR vs logical-OR code typo

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -324,7 +324,7 @@ int negamax(int alpha, int beta, int depth, SearchThread& st, SearchStack *ss, b
          */
 
         if (ss->static_eval >= (beta - 76 * improving) && board.nonPawnMat(board.sideToMove) && (depth >= 3) &&
-            ((ss - 1)->move != NULL_MOVE) && (!ttHit || tte.flag != HFALPHA | eval >= beta))
+            ((ss - 1)->move != NULL_MOVE) && (!ttHit || tte.flag != HFALPHA || eval >= beta))
         {
 
             int R = 3 + depth / 3 + std::min(3, (eval - beta) / 180);


### PR DESCRIPTION
Hi Rafid,
I'm working on a very simple (material-only) engine using Disservin's C++ Chess Library from where I found the link to your Rice project. Really enjoying reading through your well-commented Rice code. Found to typo on looking through search.cpp. Hope it helps. All the best,
John